### PR TITLE
fix: issue not created if closed and missing tool-version in daily cleanup

### DIFF
--- a/.github/workflows/daily-cleanup.yml
+++ b/.github/workflows/daily-cleanup.yml
@@ -2,7 +2,6 @@
 name: Daily cleanup cluster
 
 on:
-  pull_request: # TODO: delete me
   workflow_dispatch:
     inputs:
       max_age_hours_cluster:


### PR DESCRIPTION
This PR fixes the last failed workflow: https://github.com/camunda/camunda-tf-rosa/actions/runs/9227436512/job/25389380517

Successful run to check: https://github.com/camunda/camunda-tf-rosa/actions/runs/9227575459/job/25389811924