### PR TITLE
fix(cluster-create): follow download redirect

### DIFF
--- a/.github/actions/rosa-create-cluster/action.yml
+++ b/.github/actions/rosa-create-cluster/action.yml
@@ -92,7 +92,7 @@ runs:
     - name: Install ROSA CLI
       shell: bash
       run: |
-        curl -O "https://mirror.openshift.com/pub/openshift-v4/clients/rosa/${{ inputs.rosa-cli-version }}/rosa-linux.tar.gz"
+        curl -LO "https://mirror.openshift.com/pub/openshift-v4/clients/rosa/${{ inputs.rosa-cli-version }}/rosa-linux.tar.gz"
         tar -xvf rosa-linux.tar.gz
         sudo mv rosa /usr/local/bin/rosa
         chmod +x /usr/local/bin/rosa


### PR DESCRIPTION
related to the error in https://github.com/camunda/camunda-tf-rosa/actions/runs/10033113331/job/27734339508

Curl, by default, does not follow redirects, so we have to explicitly follow it; otherwise, the `tar.gz` will be empty.
We experienced the same back with Artifactory as it's just an interface for S3 hosted files. I guess RedHat is doing something similar.