### PR TITLE
chore(openshift): update patch release

### DIFF
--- a/.github/actions/rosa-create-cluster/action.yml
+++ b/.github/actions/rosa-create-cluster/action.yml
@@ -35,7 +35,7 @@ inputs:
     description: 'Version of the OpenShift to install'
     required: true
     # renovate: datasource=endoflife-date depName=red-hat-openshift versioning=semver
-    default: "4.16.1"
+    default: "4.16.4"
   replicas:
     description: 'Number of replicas for the ROSA cluster'
     required: true

--- a/modules/rosa-hcp/README.md
+++ b/modules/rosa-hcp/README.md
@@ -25,7 +25,7 @@
 | <a name="input_htpasswd_username"></a> [htpasswd\_username](#input\_htpasswd\_username) | htpasswd username | `string` | `"kubeadmin"` | no |
 | <a name="input_machine_cidr_block"></a> [machine\_cidr\_block](#input\_machine\_cidr\_block) | value of the CIDR block to use for the machine | `string` | `"10.0.0.0/18"` | no |
 | <a name="input_offline_access_token"></a> [offline\_access\_token](#input\_offline\_access\_token) | The Red Hat OCM API access token for your account | `string` | n/a | yes |
-| <a name="input_openshift_version"></a> [openshift\_version](#input\_openshift\_version) | The version of ROSA to be deployed | `string` | `"4.16.1"` | no |
+| <a name="input_openshift_version"></a> [openshift\_version](#input\_openshift\_version) | The version of ROSA to be deployed | `string` | `"4.16.4"` | no |
 | <a name="input_pod_cidr_block"></a> [pod\_cidr\_block](#input\_pod\_cidr\_block) | value of the CIDR block to use for the pods | `string` | `"10.0.64.0/18"` | no |
 | <a name="input_replicas"></a> [replicas](#input\_replicas) | The number of computer nodes to create. Must be a minimum of 2 for a single-AZ cluster, 3 for multi-AZ. | `string` | `"2"` | no |
 | <a name="input_service_cidr_block"></a> [service\_cidr\_block](#input\_service\_cidr\_block) | value of the CIDR block to use for the services | `string` | `"10.0.128.0/18"` | no |

--- a/modules/rosa-hcp/vars.tf
+++ b/modules/rosa-hcp/vars.tf
@@ -9,7 +9,7 @@ variable "openshift_version" {
   type        = string
   description = "The version of ROSA to be deployed"
   # renovate: datasource=endoflife-date depName=red-hat-openshift versioning=semver
-  default = "4.16.1"
+  default = "4.16.4"
   validation {
     condition     = can(regex("^[0-9]*[0-9]+.[0-9]*[0-9]+.[0-9]*[0-9]+$", var.openshift_version))
     error_message = "openshift_version must be with structure <major>.<minor>.<patch> (for example 4.13.6)."


### PR DESCRIPTION
renovate did not trigger an update as the source does not keep track of 4.16.

I'll try to find an alternative source but for now a quick fix as it may block other projects.