### PR TITLE
chore(gha): disable rosa cleanup for support case

### DIFF
--- a/.github/workflows/daily-cleanup.yml
+++ b/.github/workflows/daily-cleanup.yml
@@ -8,14 +8,14 @@ on:
         description: "Maximum age of clusters in hours"
         required: true
         default: "20"
-  pull_request:
-    # the paths should be synced with ../labeler.yml
-    paths:
-      - .github/workflows/daily-cleanup.yml
-      - .github/actions/rosa-cleanup-clusters/**
+  # pull_request:
+  #   # the paths should be synced with ../labeler.yml
+  #   paths:
+  #     - .github/workflows/daily-cleanup.yml
+  #     - .github/actions/rosa-cleanup-clusters/**
 
-  schedule:
-    - cron: '0 1 * * *' # At 01:00 everyday.
+  # schedule:
+  #   - cron: '0 1 * * *' # At 01:00 everyday.
 
 env:
   MAX_AGE_HOURS_CLUSTER: "${{ github.event.inputs.max_age_hours_cluster || '20' }}"


### PR DESCRIPTION
we have an active support case with RedHat on why ROSA clusters sometimes hang past their advertised 10 minutes creation time.

We replicated a cluster that is hanging and need it to not be cleaned up since they otherwise can't check the problem.
Therefore, disabling this scheduled / PR run temporarily.

