### PR TITLE
fix: set retry max age to 0

### DIFF
--- a/.github/workflows/daily-cleanup.yml
+++ b/.github/workflows/daily-cleanup.yml
@@ -88,7 +88,7 @@ jobs:
               with:
                   tf-bucket: ${{ env.TF_S3_BUCKET }}
                   tf-bucket-region: ${{ env.TF_S3_REGION }}
-                  max-age-hours-cluster: ${{ env.MAX_AGE_HOURS_CLUSTER }}
+                  max-age-hours-cluster: 0 # the previous step alters the age and resets it to 0
 
             - name: Notify in Slack in case of failure
               id: slack-notification


### PR DESCRIPTION
The first deletion will reset the age to 0.
related to https://github.com/camunda/camunda-tf-rosa/actions/runs/11565620995

Otherwise will omit alerts to Slack.