### PR TITLE
feat: add asdf tool cache

### DIFF
--- a/.github/workflows/daily-cleanup.yml
+++ b/.github/workflows/daily-cleanup.yml
@@ -37,6 +37,16 @@ jobs:
                   ref: ${{ github.head_ref }}
                   fetch-depth: 0
 
+            - name: Cache asdf installation
+              id: cache
+              uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+              with:
+                  path: |
+                      /home/runner/.asdf
+                  key: ${{ runner.os }}-tooling-${{ hashFiles('**/.tool-versions') }}
+                  restore-keys: |
+                      ${{ runner.os }}-tooling-
+
             - name: Install tooling using asdf
               uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,6 +55,16 @@ jobs:
                   ref: ${{ github.head_ref }}
                   fetch-depth: 0
 
+            - name: Cache asdf installation
+              id: cache
+              uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+              with:
+                  path: |
+                      /home/runner/.asdf
+                  key: ${{ runner.os }}-tooling-${{ hashFiles('**/.tool-versions') }}
+                  restore-keys: |
+                      ${{ runner.os }}-tooling-
+
             - name: Install tooling using asdf
               uses: asdf-vm/actions/install@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3
 


### PR DESCRIPTION
Adds asdf cache to speed up the installation. Only the first installation where something changed takes longer.

See Example run here: https://github.com/camunda/infraex-common-config/pull/163