### PR TITLE
lint(pre-commit): add trivy check on modules

### DIFF
--- a/.lint/trivy/trivy-scan.sh
+++ b/.lint/trivy/trivy-scan.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euxo pipefail
+
+# list of the folders that we want to parse, only if a README.md exists and no .trivy_ignore
+for dir in $(find modules -type d -maxdepth 1) $(find examples -type d -maxdepth 1); do
+  if [ -f "$dir/README.md" ] && ! [ -e "$dir/.trivy_ignore" ]; then
+      echo "Scanning terraform module with trivy: $dir"
+      trivy config --config .lint/trivy/trivy.yaml --ignorefile .trivyignore "$dir"
+  fi
+done

--- a/.lint/trivy/trivy.yaml
+++ b/.lint/trivy/trivy.yaml
@@ -1,0 +1,9 @@
+---
+quiet: false
+debug: false
+format: table
+exit-code: 1
+
+misconfiguration:
+    scanners:
+        - terraform

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,3 +65,12 @@ repos:
       rev: 0.2.3
       hooks:
           - id: yamlfmt
+
+    - repo: local
+      hooks:
+          - id: trivy-scan
+            name: Trivy Scan
+            entry: .lint/trivy/trivy-scan.sh
+            language: script
+            types: [terraform]
+            pass_filenames: false

--- a/.tool-versions
+++ b/.tool-versions
@@ -18,3 +18,5 @@ terraform-docs 0.19.0
 tflint 0.55.0
 
 tfsec 1.28.13
+
+trivy 0.58.1

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,1 @@
+AVD-AWS-0178 #(MEDIUM): VPC does not have VPC Flow Logs enabled.


### PR DESCRIPTION
Source issue: https://github.com/camunda/team-infrastructure-experience/issues/37

Extending the scope of the above issue to this repository as well, implementing a trivy scan of terraform modules (formerly tfsec).