### PR TITLE
fix(gha): cleanup clusters not copying backend correctly

### DIFF
--- a/.github/actions/rosa-cleanup-clusters/scripts/destroy-clusters.sh
+++ b/.github/actions/rosa-cleanup-clusters/scripts/destroy-clusters.sh
@@ -62,7 +62,7 @@ destroy_cluster() {
   cp -a "$MODULES_DIR." "$temp_dir" || return 1
 
   echo "Copying backend.tf in $temp_dir"
-  cp "${MODULES_DIR}..fixtures/backend.tf" "$temp_dir/backend.tf" || return 1
+  cp "${MODULES_DIR}../fixtures/backend.tf" "$temp_dir/backend.tf" || return 1
 
   tree "$MODULES_DIR" "$temp_dir" || return 1
 


### PR DESCRIPTION
This PR fixes the deletion script that was not using the correct path for retrieving the fixtures folder.
I think this cleanup action was never triggered before, explaining why it never failed.

Successful run: https://github.com/camunda/camunda-tf-rosa/actions/runs/12865344761/job/35865671788?pr=139